### PR TITLE
RDK-29232: Add support for optional ipv4 flag for getSTBip function

### DIFF
--- a/src/main/include/netsrvmgrIarm.h
+++ b/src/main/include/netsrvmgrIarm.h
@@ -81,11 +81,15 @@ typedef struct _IARM_BUS_NetSrvMgr_Iface_EventData_t {
         char activeIface[INTERFACE_SIZE];
         char allNetworkInterfaces[INTERFACE_LIST];
         char setInterface[INTERFACE_SIZE];
-	char activeIfaceIpaddr[MAX_IP_ADDRESS_LEN];
+        char activeIfaceIpaddr[MAX_IP_ADDRESS_LEN];
+        bool ipv4Request;
 	};
    char interfaceCount;
-   bool isInterfaceEnabled;
-   bool persist;
+   union {
+       bool isInterfaceEnabled;
+       bool persist;
+       bool isIpv6Address;
+   };
 } IARM_BUS_NetSrvMgr_Iface_EventData_t;
 
 typedef struct {

--- a/src/main/include/netsrvmgrUtiles.h
+++ b/src/main/include/netsrvmgrUtiles.h
@@ -162,6 +162,16 @@ bool checkInterfaceActive(char *interfaceName);
 bool getSTBip(char *stbip,bool *isIpv6);
 
 /**
+ * @brief This function is used to get STB IPv4 IP address
+ *
+ * @param[out] stbip    STB IP.
+ * @param[out] isIpv6    Internet Protocol Version.
+ *
+ * @return  Returns true if successfully gets the IP details, Otherwise returns false.
+ */
+bool getSTBipv4(char *stbip);
+
+/**
  * @brief This function gets the active interface device type(Ethernet/MOCA/WIFI).
  *
  * @param[out] devname Device type buffer to be filled.
@@ -208,6 +218,37 @@ bool check_global_v6_based_macaddress(std::string ipv6Addr,std::string macAddr);
  * @return  Returns true if successfully gets the output data from script file, Otherwise false.
  */
 bool getScriptOutput(char *scriptPath,char *scriptOutput);
+
+/**
+ * @brief This function checks for and returns a valid routable ipv4 address for the specified interface
+ *
+ * @param[in] interface         Interface name
+ * @param[out] stbip            Storage for discovered IP address
+ *
+ * @return true if we found an ipv4 address, else false
+ */
+bool getIpv4Address(std::string & interface, char *stbip);
+
+/**
+ * @brief This function checks for and returns a valid routable ipv6 address for the specified interface
+ *
+ * @param[in] interface         Interface name
+ * @param[out] stbip            Storage for discovered IP address
+ *
+ * @return true if we found an ipv6 address, else false
+ */
+bool getIpv6Address(std::string & interface, char *stbip);
+
+/**
+ * @brief This function checks for and returns a ipv4 link local address for the specified interface
+ *
+ * @param[in] interface         Interface name
+ * @param[out] stbip            Storage for discovered IP address
+ *
+ * @return true if we found an ipv4 link local address, else false
+ */
+bool getIpv4LinkLocalAddress(std::string & interface, char *stbip);
+
 }
 
 

--- a/src/main/src/netSrvMgrMain.cpp
+++ b/src/main/src/netSrvMgrMain.cpp
@@ -959,13 +959,28 @@ IARM_Result_t getSTBip(void *arg)
         bool isIpv6=false;
         IARM_BUS_NetSrvMgr_Iface_EventData_t *param = (IARM_BUS_NetSrvMgr_Iface_EventData_t *)arg;
         RDK_LOG( RDK_LOG_TRACE1, LOG_NMGR, "[%s:%d] Enter\n", __FUNCTION__, __LINE__ );
-        if(netSrvMgrUtiles::getSTBip(stbip,&isIpv6))
+        if(param->ipv4Request)
         {
-           strcpy(param->activeIfaceIpaddr,stbip);
-           RDK_LOG( RDK_LOG_INFO, LOG_NMGR, "[%s:%d] stb ipaddress : [%s].\n", __FUNCTION__, __LINE__,stbip);
+            if(netSrvMgrUtiles::getSTBipv4(stbip))
+            {
+                strcpy(param->activeIfaceIpaddr,stbip);
+                param->isIpv6Address = false;
+                RDK_LOG( RDK_LOG_INFO, LOG_NMGR, "[%s:%d] stb ipv4 address : [%s].\n", __FUNCTION__, __LINE__,stbip);
+            }
+            else
+                RDK_LOG( RDK_LOG_ERROR, LOG_NMGR, "[%s:%d] stb ipv4 address not found.\n", __FUNCTION__, __LINE__);
         }
         else
-           RDK_LOG( RDK_LOG_ERROR, LOG_NMGR, "[%s:%d] stb ipaddress not found.\n", __FUNCTION__, __LINE__);
+        {
+            if(netSrvMgrUtiles::getSTBip(stbip,&isIpv6))
+            {
+                strcpy(param->activeIfaceIpaddr,stbip);
+                param->isIpv6Address = isIpv6;
+                RDK_LOG( RDK_LOG_INFO, LOG_NMGR, "[%s:%d] stb ipaddress : [%s].\n", __FUNCTION__, __LINE__,stbip);
+            }
+            else
+                RDK_LOG( RDK_LOG_ERROR, LOG_NMGR, "[%s:%d] stb ipaddress not found.\n", __FUNCTION__, __LINE__);
+        }
         RDK_LOG( RDK_LOG_TRACE1, LOG_NMGR, "[%s:%d] Exit\n",__FUNCTION__, __LINE__ );
         return ret;
 }


### PR DESCRIPTION
    
Reason for change: Reorganise address lookup into ip4/ip6 methods,
perform ipv4 only lookup if ipv4request set.
Test Procedure: Full network regression test all platforms
Risks: Medium-Low
Signed-off-by: Kamal Mortoza <kamal.mortoza@sky.uk>